### PR TITLE
Update java build instructions and gradle to support corp building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+# Excluding Local Build folder for company-specific building
+.corp
+
 #NodeJS
 node_modules
 build

--- a/README.md
+++ b/README.md
@@ -85,6 +85,56 @@ At the moment, the repository has architecture documents and API schema doc docu
 2. Submit a working, simple pub-sub engine to use with this demo
 3. Submit working implementations of components
 
+## Local Building (Company Specific)
+
+When building locally, if you are using a corporate artifact repository, you might need to override certain settings such as mavenCentral() in gradle, for the Java projects.
+
+In order to do this, we have designated a `.gitignore`'d folder where you can leave company-specific build scripts. This folder is not managed by git and can be modified locally.
+
+### Local Gradle Use Case
+
+Create a `.corp` directory and in there you can create a `settings.gradle` file which will allow you to build all gradle projects
+```
+# in the traderX main directory
+mkdir .corp
+touch settings.gradle
+```
+
+The `settings.gradle` file should contain any overrides on your `repositories` and `plugins` block but should also contain these contents:
+
+```
+rootProject.name = 'finos-traderX'
+includeFlat 'database'
+includeFlat 'account-service'
+includeFlat 'position-service'
+includeFlat 'trade-service'
+includeFlat 'trade-processor'
+```
+
+This will include projects in directories at the same level as the .corp directory. 
+
+You can also store a separate gradle wrapper here, if you need the `distributionUrl` in your `gradle.properties`  to differ from the public internet one.
+
+To build and run these projects, you can do the following:
+
+```
+###### From traderX root #####
+# Note: gradle or ./gradlew can be used, depending on your path
+
+gradle --settings-file .corp/settings.gradle build
+
+# Build specific project
+gradle --settings-file .corp/settings.gradle database:build
+
+# Run specific project
+gradle --settings-file .corp/settings.gradle account-service:bootRun
+
+##### From inside the .corp directory ####
+cd .corp
+./gradlew build
+./gradlew account-service:bootRun
+```
+
 ## Contributing
 
 1. Fork it (<https://github.com/finos/TraderX/fork>)

--- a/account-service/build.gradle
+++ b/account-service/build.gradle
@@ -15,11 +15,6 @@ group = 'finos.traderx.account-service'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
-repositories {
-  mavenCentral()
-}
-
-
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/account-service/settings.gradle
+++ b/account-service/settings.gradle
@@ -7,4 +7,10 @@
  * in the user manual at https://docs.gradle.org/8.0.2/userguide/multi_project_builds.html
  */
 
+dependencyResolutionManagement {
+    repositories {
+        // Use Maven Central for resolving dependencies.
+        mavenCentral()
+    }
+}
 rootProject.name = 'account-service'

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -11,14 +11,8 @@ plugins {
     id 'application'
 }
 
-repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
-}
-
 dependencies {
    implementation 'com.h2database:h2:2.1.214'
-
 }
 
 application {

--- a/database/settings.gradle
+++ b/database/settings.gradle
@@ -7,5 +7,12 @@
  * in the user manual at https://docs.gradle.org/8.0.2/userguide/multi_project_builds.html
  */
 
+dependencyResolutionManagement {
+    repositories {
+        // Use Maven Central for resolving dependencies.
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'database'
 

--- a/position-service/build.gradle
+++ b/position-service/build.gradle
@@ -15,11 +15,6 @@ group = 'finos.traderx.position-service'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
-repositories {
-  mavenCentral()
-}
-
-
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/position-service/settings.gradle
+++ b/position-service/settings.gradle
@@ -7,4 +7,11 @@
  * in the user manual at https://docs.gradle.org/8.0.2/userguide/multi_project_builds.html
  */
 
+dependencyResolutionManagement {
+    repositories {
+        // Use Maven Central for resolving dependencies.
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'position-service'

--- a/trade-processor/build.gradle
+++ b/trade-processor/build.gradle
@@ -15,11 +15,6 @@ group = 'finos.traderx.position-service'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
-repositories {
-  mavenCentral()
-}
-
-
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/trade-processor/settings.gradle
+++ b/trade-processor/settings.gradle
@@ -7,4 +7,11 @@
  * in the user manual at https://docs.gradle.org/8.0.2/userguide/multi_project_builds.html
  */
 
+dependencyResolutionManagement {
+    repositories {
+        // Use Maven Central for resolving dependencies.
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'trade-processor'

--- a/trade-service/build.gradle
+++ b/trade-service/build.gradle
@@ -15,11 +15,6 @@ group = 'finos.traderx.trade-service'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
-repositories {
-  mavenCentral()
-}
-
-
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/trade-service/settings.gradle
+++ b/trade-service/settings.gradle
@@ -7,4 +7,11 @@
  * in the user manual at https://docs.gradle.org/8.0.2/userguide/multi_project_builds.html
  */
 
+ dependencyResolutionManagement {
+    repositories {
+        // Use Maven Central for resolving dependencies.
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'trade-service'


### PR DESCRIPTION
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS Corporate Contributor License Agreement.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.


**Description **
In order to support controlled corporate environments where there are managed repositories (nexus, artifactory, etc) - gradle build scripts for java need to be 'overrideable' in a way that allows companies with controlled environments to build and contribute, without their company-specific build script changes being brought back into source control. This provides a working approach to address this issue, without interfering with the existing approach to build the projects